### PR TITLE
TaskDesc

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -142,12 +142,20 @@ message JobListRequest {
   string pageToken = 4;
 }
 
+// Small description of tasks, returned by server during listing
+message TaskDesc {
+  string name = 1;
+  string projectID = 2;
+  string description = 3;
+}
+
 //Small description of jobs, returned by server during listing
 message JobDesc {
   //REQUIRED
   string jobID  = 1;
   //REQUIRED
   State state = 2;
+  TaskDesc task = 3;
 }
 
 //Return envelope

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -144,8 +144,14 @@ message JobListRequest {
 
 // Small description of tasks, returned by server during listing
 message TaskDesc {
+  //OPTIONAL
+  //user name for task
   string name = 1;
+  //OPTIONAL
+  //parameter for execution engine to define/store group information
   string projectID = 2;
+  //OPTIONAL
+  //free text description of task
   string description = 3;
 }
 
@@ -155,6 +161,7 @@ message JobDesc {
   string jobID  = 1;
   //REQUIRED
   State state = 2;
+  // REQUIRED short description of task
   TaskDesc task = 3;
 }
 


### PR DESCRIPTION
Adds TaskDesc message as a subfield (Task) of JobDesc. This is useful for the web dashboard job list, where I want to list the task name and description in the list of jobs.